### PR TITLE
Hot fix on buggy undo(), redo()

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -63,32 +63,6 @@ const initializeGame = () => {
   });
 };
 
-const undo = Module.cwrap("sokoban_undo", "bool");
-  function undoClickHandler(event) {
-    event.preventDefault();
-    console.log("undo: ", Boolean(undo()));
-    renderBoard();
-    console.log(boardToStr(), levelNumber());
-  }
-  
-  let undoBtn = document.createElement("button");
-  undoBtn.innerHTML = "undo";
-  document.body.appendChild(undoBtn);
-  undoBtn.addEventListener("click", undoClickHandler);
-
-  const redo = Module.cwrap("sokoban_redo", "bool");
-  function redoClickHandler(event) {
-    event.preventDefault();
-    console.log("redo: ", Boolean(redo()));
-    renderBoard();
-    console.log(boardToStr(), levelNumber());
-  }
-  
-  let redoBtn = document.createElement("button");
-  redoBtn.innerHTML = "redo";
-  document.body.appendChild(redoBtn);
-  redoBtn.addEventListener("click", redoClickHandler);
-
 const boardEl = document.getElementById("board");
 
 var Module = {

--- a/src/index.html
+++ b/src/index.html
@@ -63,6 +63,32 @@ const initializeGame = () => {
   });
 };
 
+const undo = Module.cwrap("sokoban_undo", "bool");
+  function undoClickHandler(event) {
+    event.preventDefault();
+    console.log("undo: ", Boolean(undo()));
+    renderBoard();
+    console.log(boardToStr(), levelNumber());
+  }
+  
+  let undoBtn = document.createElement("button");
+  undoBtn.innerHTML = "undo";
+  document.body.appendChild(undoBtn);
+  undoBtn.addEventListener("click", undoClickHandler);
+
+  const redo = Module.cwrap("sokoban_redo", "bool");
+  function redoClickHandler(event) {
+    event.preventDefault();
+    console.log("redo: ", Boolean(redo()));
+    renderBoard();
+    console.log(boardToStr(), levelNumber());
+  }
+  
+  let redoBtn = document.createElement("button");
+  redoBtn.innerHTML = "redo";
+  document.body.appendChild(redoBtn);
+  redoBtn.addEventListener("click", redoClickHandler);
+
 const boardEl = document.getElementById("board");
 
 var Module = {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,14 +40,6 @@ bool sokoban_move(char *s) {
     return soko.move((Sokoban::Direction)*s);
 }
 
-bool sokoban_undo() {
-    return soko.undo();
-}
-
-bool sokoban_redo() {
-    return soko.redo();
-}
-
 int sokoban_level() {
     return soko.level();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,15 @@ const char *sokoban_board_to_string() {
 }
 
 bool sokoban_move(char *s) {
-    return soko.move(*s);
+    return soko.move((Sokoban::Direction)*s);
+}
+
+bool sokoban_undo() {
+    return soko.undo();
+}
+
+bool sokoban_redo() {
+    return soko.redo();
 }
 
 int sokoban_level() {

--- a/src/sokoban.hpp
+++ b/src/sokoban.hpp
@@ -12,7 +12,8 @@ public:
             U = 'U',
             D = 'D',
             L = 'L',
-            R = 'R'
+            R = 'R',
+            O = 'O'
         };
 
 private:
@@ -33,25 +34,19 @@ private:
         {R, std::make_pair(0, 1)}
     };
 
-    std::unordered_map<Direction, Direction> opposite {
-        {U, D},
-        {D, U},
-        {R, L},
-        {L, R},
-    };
-
     std::vector<std::vector<std::string>> levels;
     std::vector<std::string> _board;
     unsigned int current_level;
     unsigned int py;
     unsigned int px;
     std::vector<Direction> moves;
-    std::vector<Direction> undone;
+    std::vector<std::vector<std::string>> history;
+    std::vector<std::pair<Direction, std::vector<std::string>>> undone;
 
     void locate_player();
     void move_player(int dy, int dx);
     void push_box(int dy, int dx);
-    void pull_box(int dy, int dx);
+    void update(Direction direction);
     bool make_move(Direction direction);
 
 public:

--- a/tests/unit/sokoban_test.cpp
+++ b/tests/unit/sokoban_test.cpp
@@ -493,6 +493,43 @@ TEST_SUITE("Test cases for undo()") {
         CHECK_FALSE(soko.undo());
         CHECK(soko.board() == expected);
     }
+
+    TEST_CASE("After RLR-undo, player should have not pulled the box") {
+        Sokoban soko({{
+            "#####",
+            "#@$.#",
+            "#####",
+        }});
+        std::vector<std::string> expected = {
+            "#####",
+            "#@ *#",
+            "#####",
+        };
+        CHECK(soko.move(Direction::R));
+        CHECK(soko.move(Direction::L));
+        CHECK(soko.move(Direction::R));
+        CHECK(soko.undo());
+        CHECK(soko.board() == expected);
+    }
+
+    TEST_CASE("After RLR-undo-undo, player should vacate an empty cell") {
+        Sokoban soko({{
+            "#####",
+            "#@$.#",
+            "#####",
+        }});
+        std::vector<std::string> expected = {
+            "#####",
+            "# @*#",
+            "#####",
+        };
+        CHECK(soko.move(Direction::R));
+        CHECK(soko.move(Direction::L));
+        CHECK(soko.move(Direction::R));
+        CHECK(soko.undo());
+        CHECK(soko.undo());
+        CHECK(soko.board() == expected);
+    }
 }
 
 


### PR DESCRIPTION
From the previous version, the following bugs were found:
1. When we call `undo()`, the player tries to pull the box when it's not supposed to happen
2. The player just consumed the box.

Juan and I collaborated on creating this new version of undo() and redo(). In this new version, the undo() and redo() functions store the previous states of the board. When we call `undo()`, it just reverts back to the previous state. New tests were also added to address the bugs mentioned above.