### PR TITLE
Add clickable grid, undo and refactor frontend

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,9 @@
 <body>
   <main>
     <div id="board">Loading...</div>
+    <div id="controls">
+      <button id="undo">Undo</button>
+    </div>
   </main>
 
 <script src="index.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -5,128 +5,14 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sokoban</title>
-  <style>
-  body {
-    margin: 0;
-  }
-  main {
-    padding: 1em;
-  }
-  #board {
-    font-family: "consolas", monospace;
-    font-size: 20pt;
-  }
-  #board table {
-    border-collapse: collapse;
-  }
-  .cell {
-    cursor: pointer;
-    max-width: 30px;
-    max-height: 30px;
-    min-width: 30px;
-    min-height: 30px;
-    text-align: center;
-  }
-  .wall {
-    background: black;
-    cursor: default;
-  }
-  .box, .box-on-goal {
-    background: #ddd;
-  }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <main>
     <div id="board">Loading...</div>
   </main>
 
-<script>
-const initializeGame = () => {
-  const levelNumber = Module.cwrap("sokoban_level");
-  const move = Module.cwrap(
-    "sokoban_move", // name of C function
-    "bool",         // return type
-    ["string"],     // argument types
-  );
-  const boardToStr = Module.cwrap(
-    "sokoban_board_to_string",
-    "string", // return type
-  );
-  const cellToClass = {
-    " ": "space",
-    "#": "wall",
-    "@": "player",
-    "+": "player-on-goal",
-    "$": "box",
-    "*": "box-on-goal",
-    ".": "goal",
-  };
-  const buildRowHTML = (row, rowIndex) => `
-    <tr>
-      ${[...row]
-        .map((cell, i) => `
-          <td
-            data-row="${rowIndex}"
-            data-col="${i}"
-            class="cell ${cellToClass[cell] || ""}"
-          >
-            ${cell}
-          </td>
-        `)
-        .join("")}
-    </tr>
-  `;
-  const renderBoard = () => {
-    boardEl.innerHTML = 
-      "<table><tbody>" +
-        boardToStr()
-          .split("\n")
-          .map(buildRowHTML)
-          .join("") +
-      "</tbody></table>"
-    ;
-  };
-  boardEl.addEventListener("click", event => {
-    const cell = event.target.closest("td");
-
-    if (!cell || !boardEl.contains(cell)) {
-      return;
-    }
-
-    const row = +cell.getAttribute("data-row");
-    const col = +cell.getAttribute("data-col");
-    console.log(row, col);
-  });
- 
-  Module.ccall("sokoban_initialize");
-  renderBoard();
-  const moves = {
-    ArrowLeft: "L",
-    ArrowUp: "U",
-    ArrowRight: "R",
-    ArrowDown: "D",
-  };
-
-  document.addEventListener("keydown", event => {
-    if (event.code in moves) {
-      event.preventDefault();
-      console.log(Boolean(move(moves[event.code])));
-      renderBoard();
-      console.log(boardToStr(), levelNumber());
-    }
-  });
-};
-
-const boardEl = document.getElementById("board");
-
-var Module = {
-  preRun: [],
-  postRun: [initializeGame],
-  print: text => console.log(text),
-  printErr: text => console.error(text),
-};
-</script>
+<script src="index.js"></script>
 <script async src="sokoban.js"></script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -6,13 +6,40 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sokoban</title>
   <style>
+  body {
+    margin: 0;
+  }
+  main {
+    padding: 1em;
+  }
   #board {
-    font-family: monospace;
+    font-family: "consolas", monospace;
+    font-size: 20pt;
+  }
+  #board table {
+    border-collapse: collapse;
+  }
+  .cell {
+    cursor: pointer;
+    max-width: 30px;
+    max-height: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    text-align: center;
+  }
+  .wall {
+    background: black;
+    cursor: default;
+  }
+  .box, .box-on-goal {
+    background: #ddd;
   }
   </style>
 </head>
 <body>
-  <div id="board">Loading...</div>
+  <main>
+    <div id="board">Loading...</div>
+  </main>
 
 <script>
 const initializeGame = () => {
@@ -26,23 +53,51 @@ const initializeGame = () => {
     "sokoban_board_to_string",
     "string", // return type
   );
-  const buildRowHTML = row => `
+  const cellToClass = {
+    " ": "space",
+    "#": "wall",
+    "@": "player",
+    "+": "player-on-goal",
+    "$": "box",
+    "*": "box-on-goal",
+    ".": "goal",
+  };
+  const buildRowHTML = (row, rowIndex) => `
     <tr>
       ${[...row]
-        .map(cell => `<td class="cell">${cell}</td>`)
+        .map((cell, i) => `
+          <td
+            data-row="${rowIndex}"
+            data-col="${i}"
+            class="cell ${cellToClass[cell] || ""}"
+          >
+            ${cell}
+          </td>
+        `)
         .join("")}
     </tr>
   `;
   const renderBoard = () => {
     boardEl.innerHTML = 
-      "<table>" +
+      "<table><tbody>" +
         boardToStr()
           .split("\n")
           .map(buildRowHTML)
           .join("") +
-      "</table>"
+      "</tbody></table>"
     ;
   };
+  boardEl.addEventListener("click", event => {
+    const cell = event.target.closest("td");
+
+    if (!cell || !boardEl.contains(cell)) {
+      return;
+    }
+
+    const row = +cell.getAttribute("data-row");
+    const col = +cell.getAttribute("data-col");
+    console.log(row, col);
+  });
  
   Module.ccall("sokoban_initialize");
   renderBoard();

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,85 @@
+const initializeGame = () => {
+  const levelNumber = Module.cwrap("sokoban_level");
+  const move = Module.cwrap(
+    "sokoban_move", // name of C function
+    "bool",         // return type
+    ["string"],     // argument types
+  );
+  const boardToStr = Module.cwrap(
+    "sokoban_board_to_string",
+    "string", // return type
+  );
+  const cellToClass = {
+    " ": "space",
+    "#": "wall",
+    "@": "player",
+    "+": "player-on-goal",
+    "$": "box",
+    "*": "box-on-goal",
+    ".": "goal",
+  };
+  const buildRowHTML = (row, rowIndex) => `
+    <tr>
+      ${[...row]
+        .map((cell, i) => `
+          <td
+            data-row="${rowIndex}"
+            data-col="${i}"
+            class="cell ${cellToClass[cell] || ""}"
+          >
+            ${cell}
+          </td>
+        `)
+        .join("")}
+    </tr>
+  `;
+  const renderBoard = () => {
+    boardEl.innerHTML = 
+      "<table><tbody>" +
+        boardToStr()
+          .split("\n")
+          .map(buildRowHTML)
+          .join("") +
+      "</tbody></table>"
+    ;
+  };
+  boardEl.addEventListener("click", event => {
+    const cell = event.target.closest("td");
+
+    if (!cell || !boardEl.contains(cell)) {
+      return;
+    }
+
+    const row = +cell.getAttribute("data-row");
+    const col = +cell.getAttribute("data-col");
+    console.log(row, col);
+  });
+ 
+  Module.ccall("sokoban_initialize");
+  renderBoard();
+  const moves = {
+    ArrowLeft: "L",
+    ArrowUp: "U",
+    ArrowRight: "R",
+    ArrowDown: "D",
+  };
+
+  document.addEventListener("keydown", event => {
+    if (event.code in moves) {
+      event.preventDefault();
+      console.log(Boolean(move(moves[event.code])));
+      renderBoard();
+      console.log(boardToStr(), levelNumber());
+    }
+  });
+};
+
+const boardEl = document.getElementById("board");
+
+var Module = {
+  preRun: [],
+  postRun: [initializeGame],
+  print: text => console.log(text),
+  printErr: text => console.error(text),
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,10 @@ bool sokoban_move(char *s) {
     return soko.move((Sokoban::Direction)*s);
 }
 
+bool sokoban_undo() {
+    return soko.undo();
+}
+
 int sokoban_level() {
     return soko.level();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,10 +18,16 @@ static std::string joined_board;
 extern "C" {
 void sokoban_initialize() {
     std::vector<std::vector<std::string>> levels{{
-        "#######",
-        "#  $ .#",
-        "#@  ###",
-        "#####",
+        // GRIGoRusha: Shito-Krito #86
+        "  #########",
+        "  #   #  @#",
+        " ##  .$.# #",
+        " #  ##  $ #",
+        "##  .$*#$##",
+        "#  #$#   # ",
+        "#  . .# ## ",
+        "####    #  ",
+        "   ######  ",
     }};
     soko = {levels};
 }
@@ -48,3 +54,4 @@ int sokoban_level() {
 int main() {
     std::cout << "Hello Emscripten!\n";
 }
+

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,31 @@
+body {
+  margin: 0;
+}
+
+main {
+  padding: 1em;
+}
+
+#board {
+  font-family: "consolas", monospace;
+  font-size: 20pt;
+}
+#board table {
+  border-collapse: collapse;
+}
+#board .cell {
+  cursor: pointer;
+  max-width: 30px;
+  max-height: 30px;
+  min-width: 30px;
+  min-height: 30px;
+  text-align: center;
+}
+#board .wall {
+  background: black;
+  cursor: default;
+}
+#board .box, .box-on-goal {
+  background: #ddd;
+}
+


### PR DESCRIPTION
I used [event delegation](https://javascript.info/event-delegation) and `data-` attributes to determine which cell was clicked. The advantage is that we can use one event listener for the entire grid instead of having to re-attach them every time the table elements change.